### PR TITLE
feat: redirect to go.vshn.ch for retargeting

### DIFF
--- a/contactform/app.py
+++ b/contactform/app.py
@@ -1,5 +1,8 @@
+import hashlib
 import logging
 import threading
+from urllib.parse import urlencode
+
 from flask import (
     Flask,
     render_template,
@@ -202,7 +205,18 @@ def index():
         else:
             flash("Thanks for submitting", "success")
 
-        return render_template("success.html")
+        # Redirect to go.vshn.ch for retargeting pixel firing
+        email_hash = hashlib.sha256(
+            email_data.lower().strip().encode()
+        ).hexdigest()
+        params = urlencode({
+            "event": "1",
+            "e": email_hash,
+            "utm_source": "event",
+            "utm_medium": "booth",
+            "utm_campaign": config.CAMPAIGN_NAME,
+        })
+        return redirect(f"https://go.vshn.ch/?{params}")
     else:
         return render_template("form.html", form=form)
 


### PR DESCRIPTION
## Summary
- After successful event lead submission, redirect to `go.vshn.ch` instead of rendering a static success page
- Includes SHA-256 hashed email, event flag, and UTM parameters in the redirect URL
- Fires retargeting pixels (Google Ads, LinkedIn Insight Tag) on the landing page so event visitors enter remarketing audiences

**URL format:** `go.vshn.ch/?event=1&e=<sha256>&utm_source=event&utm_medium=booth&utm_campaign=<name>`

Companion PR in landingpager handles the `?event=1` parameter on go.vshn.ch (UI state, Plausible event).

## Test plan
- [ ] Submit form locally, verify 302 redirect to go.vshn.ch with correct params
- [ ] Verify email hash is lowercase SHA-256 of the submitted email
- [ ] Verify UTM campaign matches the configured CAMPAIGN_NAME

🤖 Generated with [Claude Code](https://claude.com/claude-code)