### PR TITLE
Add /healthz endpoints, CI smoke tests, and lazy Odoo init

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,154 @@
+name: Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  podstatus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.podstatus
+          platforms: linux/amd64
+          load: true
+          tags: podstatus:test
+
+      - name: Create dummy kubeconfig
+        run: |
+          mkdir -p /tmp/kube
+          printf '%s\n' \
+            'apiVersion: v1' \
+            'kind: Config' \
+            'clusters:' \
+            '- cluster:' \
+            '    server: https://localhost:6443' \
+            '  name: dummy' \
+            'contexts:' \
+            '- context:' \
+            '    cluster: dummy' \
+            '    user: dummy' \
+            '  name: dummy' \
+            'current-context: dummy' \
+            'users:' \
+            '- name: dummy' \
+            '  user: {}' \
+            > /tmp/kube/config
+
+      - name: Run container
+        run: |
+          docker run -d --name podstatus \
+            -e FLASK_APP_SECRET_KEY=test \
+            -e K8S_NAMESPACE=default \
+            -e CHAOS_BASIC_AUTH_USERNAME=test \
+            -e CHAOS_BASIC_AUTH_PASSWORD=test \
+            -e KUBECONFIG=/tmp/kube/config \
+            -v /tmp/kube:/tmp/kube:ro \
+            -p 8080:8080 \
+            podstatus:test
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/healthz; then
+              echo " Smoke test passed"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Smoke test failed"
+          docker logs podstatus
+          exit 1
+
+  contactform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.contactform
+          platforms: linux/amd64
+          load: true
+          tags: contactform:test
+
+      - name: Run container
+        run: |
+          docker run -d --name contactform \
+            -e FLASK_APP_SECRET_KEY=test \
+            -e PRINTER_IP=0.0.0.0 \
+            -e ODOO_URL=http://localhost \
+            -e ODOO_DB=test \
+            -e ODOO_USERNAME=test \
+            -e ODOO_PASSWORD=test \
+            -e TAG_NAME=test \
+            -e CAMPAIGN_NAME=test \
+            -e SOURCE_NAME=test \
+            -e CSV_FILE_PATH=/tmp/test.csv \
+            -e BASIC_AUTH_USERNAME=test \
+            -e BASIC_AUTH_PASSWORD=test \
+            -p 8080:8080 \
+            contactform:test
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/healthz; then
+              echo " Smoke test passed"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Smoke test failed"
+          docker logs contactform
+          exit 1
+
+  demopod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.demopod
+          platforms: linux/amd64
+          load: true
+          tags: demopod:test
+
+      - name: Run container
+        run: |
+          docker run -d --name demopod \
+            -p 8080:8080 \
+            demopod:test
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health; then
+              echo " Smoke test passed"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Smoke test failed"
+          docker logs demopod
+          exit 1

--- a/contactform/app.py
+++ b/contactform/app.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import threading
 from flask import (
     Flask,
@@ -37,15 +38,36 @@ app.config["BOOTSTRAP_BOOTSWATCH_THEME"] = "sandstone"
 app.config["BOOTSTRAP_BTN_SIZE"] = "lg"
 app.config["BOOTSTRAP_SERVE_LOCAL"] = True
 
-# Initialize Odoo client and look up campaign and source IDs
-odoo_client = OdooClient(
-    config.ODOO_URL, config.ODOO_DB, config.ODOO_USERNAME, config.ODOO_PASSWORD
-)
-try:
-    config.lookup_ids(odoo_client)
-except ValueError as e:
-    logging.error(e)
-    exit(1)
+# Odoo client — initialized in a background thread so the app starts
+# immediately (healthz works, k8s probes pass) and the data is usually
+# ready by the time a visitor reaches the form.
+_odoo_client = None
+_odoo_countries = None
+_odoo_ready = threading.Event()
+
+
+def _init_odoo():
+    global _odoo_client, _odoo_countries
+    delay = 1
+    max_delay = 900  # 15 minutes
+    while True:
+        try:
+            _odoo_client = OdooClient(
+                config.ODOO_URL, config.ODOO_DB, config.ODOO_USERNAME, config.ODOO_PASSWORD
+            )
+            config.lookup_ids(_odoo_client)
+            _odoo_countries = load_countries(_odoo_client)
+            logging.info("Odoo initialization complete")
+            break
+        except Exception as e:
+            logging.error(f"Odoo initialization failed: {e}, retrying in {delay}s")
+            _odoo_client = None
+            time.sleep(delay)
+            delay = min(delay * 2, max_delay)
+    _odoo_ready.set()
+
+
+threading.Thread(target=_init_odoo, daemon=True).start()
 
 # Configure printer
 printer_config = Configuration(
@@ -67,7 +89,7 @@ class LeadForm(FlaskForm):
     company = StringField("Company")
     job_position = StringField("Job Position")
     phone = TelField()
-    country = SelectField("Country", choices=load_countries(odoo_client))
+    country = SelectField("Country", choices=[])
     notes = TextAreaField("What can VSHN help you with?", render_kw={"rows": 5})
     submit = SubmitField()
 
@@ -99,9 +121,20 @@ def is_duplicate_submission(email, csv_file_path):
     return False
 
 
+@app.route("/healthz")
+def healthz():
+    return "ok"
+
+
 @app.route("/", methods=["GET", "POST"])
 def index():
+    if not _odoo_ready.is_set():
+        _odoo_ready.wait()
+    if _odoo_client is None:
+        _init_odoo()
+
     form = LeadForm()
+    form.country.choices = _odoo_countries or []
 
     if form.validate_on_submit():
         # Check if the form submission is a duplicate
@@ -140,7 +173,7 @@ def index():
             )
             # Create lead in Odoo
             try:
-                lead_id = odoo_client.create(
+                lead_id = _odoo_client.create(
                     "crm.lead",
                     {
                         "name": f"Event Lead: {form.name.data}",
@@ -221,7 +254,7 @@ def config_endpoint():
 
     if form.validate_on_submit():
         try:
-            config.CAMPAIGN_ID = odoo_client.find_id_by_name(
+            config.CAMPAIGN_ID = _odoo_client.find_id_by_name(
                 "utm.campaign", form.campaign_name.data
             )
             config.CAMPAIGN_NAME = form.campaign_name.data

--- a/deployment/apps/contactform/deployment.yaml
+++ b/deployment/apps/contactform/deployment.yaml
@@ -36,11 +36,11 @@ spec:
               mountPath: /opt/data
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           resources: {}
       volumes:

--- a/deployment/apps/podstatus/deployment.yaml
+++ b/deployment/apps/podstatus/deployment.yaml
@@ -35,10 +35,10 @@ spec:
                 name: podstatus-env
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           resources: {}

--- a/podstatus/app.py
+++ b/podstatus/app.py
@@ -175,7 +175,10 @@ def create_app():
         logging.info(f"Display mode toggled to {display_mode['value']}")
         return jsonify({"mode": display_mode["value"]})
 
-    # Define routes
+    @app.route("/healthz")
+    def healthz():
+        return "ok"
+
     @app.route("/")
     def index():
         return render_template("index.html", kill_count_seed=kill_count_seed["value"])

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge dev tool updates",
+      "matchPackageNames": ["black", "ruff"],
+      "automerge": true
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
       "description": "Automerge dev tool updates",
       "matchPackageNames": ["black", "ruff"],
       "automerge": true
+    },
+    {
+      "description": "Automerge gunicorn patch and minor updates",
+      "matchPackageNames": ["gunicorn"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add lightweight `/healthz` endpoint to podstatus and contactform, used by both K8s liveness/readiness probes and CI smoke tests
- Add CI smoke test workflow that builds all 3 Docker images (amd64-only) and verifies they start and serve health checks — runs on all PRs
- Move contactform Odoo client initialization to a background thread with exponential backoff retry (1s → 15min cap), so the app starts immediately even when Odoo or network is unavailable (Raspberry Pi booting before wifi connects)
- On form render: wait for background init to complete, or retry synchronously if it failed
- Configure Renovate to automerge GitHub Actions, dev tools (black, ruff), and gunicorn patch/minor updates

## Motivation
No CI checks existed for PRs — Renovate dependency updates couldn't be validated. This enables automerging for low-risk dependency bumps. The `/healthz` endpoints also replace probing `/` which renders full templates and hits external services.

## Test plan
- [ ] Verify smoke test workflow runs on this PR
- [ ] Check podstatus `/healthz` returns `ok`
- [ ] Check contactform `/healthz` returns `ok` without Odoo
- [ ] Verify contactform form loads correctly once Odoo connects
- [ ] Confirm K8s deployments use `/healthz` for probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)